### PR TITLE
Swapped err and msg in MessageCallback

### DIFF
--- a/packages/library/src/brokers/MessageBroker.ts
+++ b/packages/library/src/brokers/MessageBroker.ts
@@ -1,5 +1,5 @@
 // The Message type should be created by us at a later point. It must be compatible with Kafka and
-export type MessageCallback<T> = (err: any, message: T) => void;
+export type MessageCallback<T> = (message: T, err: any) => void;
 export type ErrorCallback = (err: any) => void;
 
 // export type GenericTopicOptions = {

--- a/packages/library/src/brokers/kafka/main.ts
+++ b/packages/library/src/brokers/kafka/main.ts
@@ -294,8 +294,8 @@ export default class Kafka extends MessageBroker {
       throw new Error(`No listener found for topic "${topic}"`);
 
     this.consumers[topic]!.on('message', (msg: Message) =>
-      callback!(null, formatMessageToKafkaMessage(msg))
+      callback!(formatMessageToKafkaMessage(msg), null)
     );
-    this.consumers[topic]!.on('error', (err: any) => callback!(err, null));
+    this.consumers[topic]!.on('error', (err: any) => callback!(null, err));
   }
 }


### PR DESCRIPTION
The `MessageCallback<T>` had the arguments swapped.
They were `(err: any, message: T) => void;` and are now `(message: T, err: any) => void;`