### PR TITLE
Refactor: init of brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,11 +717,17 @@ const topics = {
   topic2: null,
 }
 
-const kafka = Kafka(clientOptions, topics);
+Kafka(clientOptions, topics).then(client => {
 
-kafka.consume('topic2', { autoCommit: true }, (data, error) => console.log(data.message));
+  kafka.consume('topic2', { autoCommit: true }, (data, error) => {
 
-kafka.send('topic2', 'Hello, topic2!');
+    console.log(data.message)
+
+  });
+
+  kafka.send('topic2', 'Hello, topic2!');
+});
+
 ```
 
   </section>
@@ -733,19 +739,21 @@ kafka.send('topic2', 'Hello, topic2!');
 <br>
 
 <!-- Rabbit section -->
-<section id=rabbit-init>
+<section id=rabbit>
 
 ## **RabbitMQ**
 
+<section id=rabbit-init>
+
 ### **Initilization**
 
-Initilizing RabbitMQ is similar to the syntax you have seen previously with our standards and Kakfa. With RabbitMQ, we use the "createRabbitClass" factory function to instantiate a variable to act as our broker.
+Initilizing RabbitMQ is similar to the syntax you have seen previously with our standards and Kakfa. With RabbitMQ, we use the "Rabbit" factory function to instantiate a variable to act as our broker.
 
 Is that an await? Yes, yes it is. Our RabbitMQ message broker can be instantiated using promises.
 
 ```TypeScript
 
-const rabbit = await createRabbitClass(clientOptions, topics);
+const rabbit = await Rabbit(clientOptions, topics);
 
 ```
 
@@ -757,6 +765,8 @@ With Codename Hermes, you can create a customaizable rabbit broker for any occas
 
 ```TypeScript
 {
+  host: string;
+  port: number;
   username?: string;
   password?: string;
   protocol?: 'amqp' | 'amqps';
@@ -947,15 +957,14 @@ An example of implementing a topic might look like:
 
 ```TypeScript
 const topics = {
-topic1: {
-  exchange: {
-    name: "topics",
+  topic1: {
+    exchange: {
+      name: "topics",
+      durable: false,
+      type: "topic",
+    },
     durable: false,
-    type: "topic",
   },
-  durable: false,
-  key: "hermes",
-},
 };
 ```
 
@@ -1026,7 +1035,7 @@ Please refer to [Publish options](https://amqp-node.github.io/amqplib/channel_ap
 _Quick example_
 
 ```TypeScript
-rabbit.send("topic1", "hello from sender.ts in ch lib test");
+rabbit.send("topic1", "Hello topic1!");
 
 ```
 
@@ -1046,9 +1055,10 @@ _Comming soon!_
 
 ```TypeScript
 
-import ch, { RabbitTopic, createRabbitClass } from "library";
-
-const clientOptions = { host: "localhost", port: 5672 };
+const clientOptions = {
+  host: "localhost",
+  port: 5672,
+};
 
 const topics: RabbitTopic = {
   topic1: {
@@ -1058,18 +1068,21 @@ const topics: RabbitTopic = {
       type: "topic",
     },
     durable: false,
-    key: "hermes",
   },
 };
 
-const rabbit = await createRabbitClass(clientOptions,topics);
+Rabbit(clientOptions, topics).then(client => {
 
-rabbit.send("topic1", "hello from sender.ts in ch lib test");
+  rabbit.send("topic1", "Hello topic1!");
+
+});
+
 
 ```
 
   <!-- Description for Rabbit implementation -->
   <!-- Docs -->
+</section>
 </section>
 
 <br>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@
 
 <br>
 
+# Installation
+
+### **NPM**
+
+`npm i @codename-hermes/library`
+
+### **Yarn**
+
+`yarn add @codename-hermes/library`
+
+<br>
+
   <!-- Directory -->
   <div align="left">
   

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ consume(topicName: string, callback: MessageCallback)
 A MessageCallback will always be based off the example below, although it may change from broker to broker.
 
 ```TypeScript
-(data: GenericMessage<any>, error?: any) => void
+(error: any | null, data: GenericMessage<any> | null) => void
 ```
 
 Data will always look like:

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -16,6 +16,18 @@
 
 <br>
 
+# Installation
+
+### **NPM**
+
+`npm i @codename-hermes/library`
+
+### **Yarn**
+
+`yarn add @codename-hermes/library`
+
+<br>
+
   <!-- Directory -->
   <div align="left">
   

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -165,7 +165,7 @@ consume(topicName: string, callback: MessageCallback)
 A MessageCallback will always be based off the example below, although it may change from broker to broker.
 
 ```TypeScript
-(data: GenericMessage<any>, error?: any) => void
+(error: any | null, data: GenericMessage<any> | null) => void
 ```
 
 Data will always look like:

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -717,11 +717,17 @@ const topics = {
   topic2: null,
 }
 
-const kafka = Kafka(clientOptions, topics);
+Kafka(clientOptions, topics).then(client => {
 
-kafka.consume('topic2', { autoCommit: true }, (data, error) => console.log(data.message));
+  kafka.consume('topic2', { autoCommit: true }, (data, error) => {
 
-kafka.send('topic2', 'Hello, topic2!');
+    console.log(data.message)
+
+  });
+
+  kafka.send('topic2', 'Hello, topic2!');
+});
+
 ```
 
   </section>
@@ -741,13 +747,13 @@ kafka.send('topic2', 'Hello, topic2!');
 
 ### **Initilization**
 
-Initilizing RabbitMQ is similar to the syntax you have seen previously with our standards and Kakfa. With RabbitMQ, we use the "createRabbitClass" factory function to instantiate a variable to act as our broker.
+Initilizing RabbitMQ is similar to the syntax you have seen previously with our standards and Kakfa. With RabbitMQ, we use the "Rabbit" factory function to instantiate a variable to act as our broker.
 
 Is that an await? Yes, yes it is. Our RabbitMQ message broker can be instantiated using promises.
 
 ```TypeScript
 
-const rabbit = await createRabbitClass(clientOptions, topics);
+const rabbit = await Rabbit(clientOptions, topics);
 
 ```
 
@@ -759,6 +765,8 @@ With Codename Hermes, you can create a customaizable rabbit broker for any occas
 
 ```TypeScript
 {
+  host: string;
+  port: number;
   username?: string;
   password?: string;
   protocol?: 'amqp' | 'amqps';
@@ -949,15 +957,14 @@ An example of implementing a topic might look like:
 
 ```TypeScript
 const topics = {
-topic1: {
-  exchange: {
-    name: "topics",
+  topic1: {
+    exchange: {
+      name: "topics",
+      durable: false,
+      type: "topic",
+    },
     durable: false,
-    type: "topic",
   },
-  durable: false,
-  key: "hermes",
-},
 };
 ```
 
@@ -1028,7 +1035,7 @@ Please refer to [Publish options](https://amqp-node.github.io/amqplib/channel_ap
 _Quick example_
 
 ```TypeScript
-rabbit.send("topic1", "hello from sender.ts in ch lib test");
+rabbit.send("topic1", "Hello topic1!");
 
 ```
 
@@ -1048,9 +1055,10 @@ _Comming soon!_
 
 ```TypeScript
 
-import ch, { RabbitTopic, createRabbitClass } from "library";
-
-const clientOptions = { host: "localhost", port: 5672 };
+const clientOptions = {
+  host: "localhost",
+  port: 5672,
+};
 
 const topics: RabbitTopic = {
   topic1: {
@@ -1060,13 +1068,15 @@ const topics: RabbitTopic = {
       type: "topic",
     },
     durable: false,
-    key: "hermes",
   },
 };
 
-const rabbit = await createRabbitClass(clientOptions,topics);
+Rabbit(clientOptions, topics).then(client => {
 
-rabbit.send("topic1", "hello from sender.ts in ch lib test");
+  rabbit.send("topic1", "Hello topic1!");
+
+});
+
 
 ```
 

--- a/packages/library/src/brokers/MessageBroker.ts
+++ b/packages/library/src/brokers/MessageBroker.ts
@@ -1,3 +1,6 @@
+import { Channel, Connection } from 'amqplib';
+import { KafkaClient, Producer } from 'kafka-node';
+
 // The Message type should be created by us at a later point. It must be compatible with Kafka and
 export type MessageCallback<T> = (err: any, message: T) => void;
 export type ErrorCallback = (err: any) => void;
@@ -36,15 +39,17 @@ export type GenericClientOptions = {
 
 // The generic message object
 // Each broker will have their own specific details added.
-export type GenericMessage = {
+export type GenericMessage<T> = T & {
   topic: string;
   message: string;
 };
 
-// TODO: add overloads to abstract class.
-
 export default abstract class MessageBroker {
-  constructor(connection: GenericClientOptions, topics: GenericTopic) {}
+  constructor(
+    client: KafkaClient | Connection,
+    producer: Producer | Channel,
+    topics: GenericTopic
+  ) {}
 
   // This will be defined in the specific broker class
   abstract send(topic: string, message: string | string[]): void;
@@ -57,6 +62,7 @@ export default abstract class MessageBroker {
 
   // This will be defined in the specific broker class
   // abstract consume(topic: string): Promise<GenericMessage | null>;
+  abstract consume(topic: string, callback: MessageCallback<any>): void;
   abstract consume(
     topic: string,
     listenerOptions: GenericListenerOptions,

--- a/packages/library/src/brokers/kafka/main.ts
+++ b/packages/library/src/brokers/kafka/main.ts
@@ -135,11 +135,7 @@ export async function createKafkaClass(
     kafkaClient.on('error', (error) => reject(error));
     kafkaClient.on('ready', () => {
       const producer = new Producer(kafkaClient, producerOptions);
-
-      producer.on('error', (error) => reject(error));
-      producer.on('ready', () => {
-        resolve(new Kafka(kafkaClient, producer, topics));
-      });
+      resolve(new Kafka(kafkaClient, producer, topics));
     });
   });
 }

--- a/packages/library/src/brokers/kafka/main.ts
+++ b/packages/library/src/brokers/kafka/main.ts
@@ -56,12 +56,12 @@ export type KafkaListenerOptions = GenericListenerOptions & {
   // keyEncoding?: 'buffer' | 'utf8';
 };
 
-export type KafkaMessage = GenericMessage & {
+export type KafkaMessage = GenericMessage<{
   offset?: number;
   partition?: number;
   highWaterOffset?: number;
   key?: string;
-};
+}>;
 
 //TODO: error handling lol
 //TODO: comments lol
@@ -153,7 +153,7 @@ export async function createKafkaClass(
  */
 
 // TODO: re-add abstract message broker class
-export default class Kafka /*extends MessageBroker*/ {
+export default class Kafka extends MessageBroker {
   private client: KafkaClient;
   private topics: KafkaTopic;
   private producer: Producer;
@@ -161,7 +161,7 @@ export default class Kafka /*extends MessageBroker*/ {
     [topic: string]: Consumer;
   };
   constructor(client: KafkaClient, producer: Producer, topics: KafkaTopic) {
-    // super(client, topics);
+    super(client, producer, topics);
     this.client = client;
     this.topics = topics;
     this.producer = producer;

--- a/packages/library/src/brokers/rabbit/main.ts
+++ b/packages/library/src/brokers/rabbit/main.ts
@@ -41,7 +41,7 @@ export type RabbitListenerOptions = GenericListenerOptions & {
   arguments?: any;
 };
 
-export type RabbitMessage = GenericMessage & {};
+export type RabbitMessage = GenericMessage<{}>;
 
 //function to act as asynchronous factory function
 /**
@@ -92,13 +92,13 @@ export async function createRabbitClass(
 }
 
 // TODO: Add error handling
-export default class Rabbit /*extends MessageBroker*/ {
+export default class Rabbit extends MessageBroker {
   private client: Connection;
   private channel: amqp.Channel;
   private topics: RabbitTopic;
   private consumerTags: { [topicName: string]: RabbitListenerOptions };
   constructor(client: Connection, channel: amqp.Channel, topics: RabbitTopic) {
-    // super(connection, topics);
+    super(client, channel, topics);
 
     this.client = client;
     this.channel = channel;
@@ -119,7 +119,8 @@ export default class Rabbit /*extends MessageBroker*/ {
     );
   }
 
-  listener(topics: string, options?: RabbitListenerOptions) {
+  // This isn't really needed 🤷‍♂️
+  protected listener(topics: string, options?: RabbitListenerOptions) {
     const convertedOptions = convertGenericListenerConfigToRabbitAmqpConfig(
       options ?? {}
     );


### PR DESCRIPTION
This refactoring will allow for:

- Easier testing of our abstraction implementation via `MockClient` and `MockProducer`
- Easier maintainability and readability

Roadmap:

- [x] Remove client instantiation from the individual broker classes and move them into the factory init functions. _In progress._
- [x] Reorganize abstract `MessageBroker` class to support clients passed at instantiation.
- [x] Update Docs